### PR TITLE
Proposed fix for https://github.com/alexeypetrushin/vos/issues/1

### DIFF
--- a/lib/vos/drivers/ssh.rb
+++ b/lib/vos/drivers/ssh.rb
@@ -106,8 +106,7 @@ module Vos
           unless @home
             command = 'cd ~; pwd'
             code, stdout, stderr = exec command
-            raise "can't execute '#{command}'!" unless code == 0
-            @home = stdout.gsub("\n", '')
+            @home = code == 0 ? stdout.gsub("\n", '') : ''
           end
           @home
         end


### PR DESCRIPTION
Allow empty home because some servers allow SFTP access only (no SSH shell).

Not sure if this has any unwanted side-effects but 
1) it works for me :-) and 
2) the raised error is not helpful in any situation i can imagine. this happens after successful authentication in any case.

So please consider pulling this.
