### PR TITLE
proposed fix for https://github.com/alexeypetrushin/vos/issues/4

### DIFF
--- a/lib/vos/drivers/ssh_vfs_storage.rb
+++ b/lib/vos/drivers/ssh_vfs_storage.rb
@@ -7,6 +7,7 @@ module Vos
         end
 
         def write data
+          data = data.force_encoding(Encoding::ASCII_8BIT)
           @out.write data
         end
       end


### PR DESCRIPTION
this cures the "incompatible character encodings" exception by forcing strings being written into ASCII-8BIT encoding
