### PR TITLE
Return attributes for dirs, too, so that exist? works for them

### DIFF
--- a/lib/vos/drivers/s3_vfs_storage.rb
+++ b/lib/vos/drivers/s3_vfs_storage.rb
@@ -24,14 +24,18 @@ module Vos
 
         file = bucket.objects[path]
         if file.exists?
-          attrs = {}
-          attrs[:file] = true
-          attrs[:dir] = false
-          attrs[:size] = file.content_length
-          attrs[:updated_at] = file.last_modified
-          attrs
+          {
+            :file       => true,
+            :dir        => false,
+            :size       => file.content_length,
+            :updated_at => file.last_modified
+          }
+        elsif dir_exists?(path)
+          {
+            :file       => false,
+            :dir        => true
+          }
         else
-          # There's no dirs in S3, so we always return nil
           nil
         end
       end


### PR DESCRIPTION
calling .exist? on a remote dir should return true. directories might not "physically exist" on S3 but used as a virtual file system the answer given by Vos::Drivers::S3VfsStorage#dir_exists? makes more sense.
