### PR TITLE
Allow more general write options for S3

### DIFF
--- a/lib/vos/drivers/s3.rb
+++ b/lib/vos/drivers/s3.rb
@@ -10,7 +10,7 @@ module Vos
       def initialize options = {}
         options = options.clone
         @bucket_name = options.delete(:bucket) || raise("S3 bucket not provided!")
-        @acl = options.delete(:acl) || :public_read
+        @write_options = {:acl => :public_read}.merge(options.delete(:write_options))
         @options = options
       end
 
@@ -57,7 +57,7 @@ module Vos
       end
 
       protected
-        attr_reader :options, :bucket_name, :acl
+        attr_reader :options, :bucket_name, :write_options
     end
   end
 end

--- a/lib/vos/drivers/s3_vfs_storage.rb
+++ b/lib/vos/drivers/s3_vfs_storage.rb
@@ -58,11 +58,11 @@ module Vos
           writer = Writer.new
           writer.write file.read if file.exists?
           block.call writer
-          file.write writer.data, acl: acl
+          file.write writer.data, write_options
         else
           writer = Writer.new
           block.call writer
-          file.write writer.data, acl: acl
+          file.write writer.data, write_options
         end
       end
 


### PR DESCRIPTION
This change allows for options like cache control headers to be set while writing to S3, e.g.

```
driver = Vos::Drivers::S3.new \
  access_key_id: aws_key, secret_access_key: aws_secret, bucket: bucket_name,
  write_options: {:cache_control => 'public,max-age=31536000'}
```

Please consider pulling this.
