### PR TITLE
fix prefix for root dir (https://github.com/alexeypetrushin/vfs/issues/4)

### DIFF
--- a/lib/vos/drivers/s3_vfs_storage.rb
+++ b/lib/vos/drivers/s3_vfs_storage.rb
@@ -140,7 +140,8 @@ module Vos
         end
 
         def normalize_path path
-          path.sub(/^\//, '')
+          path = path.sub(/^\//, '')
+          path == '' ? nil : path
         end
     end
   end


### PR DESCRIPTION
:prefix => '' does not work as expected,
:prefix => nil means top level

Btw. I do not know whether this breaks something else. Can you include some info on how to run the specs in the README?
